### PR TITLE
Refer to lesson status pages, instead of replicating it

### DIFF
--- a/_episodes/02-curricular.md
+++ b/_episodes/02-curricular.md
@@ -27,8 +27,9 @@ for development of new lessons. Your involvement with this process
 you are a Maintainer for. Some lessons have been around for a while
 and are quite mature and stable, while others are newer and are still in
 active development. You can check the status of our lesson rosters on
-[Software-Carpentry.org/lessons](https://software-carpentry.org/lessons/) and 
-[DataCarpentry.org/lessons](https://datacarpentry.org/lessons/).
+[Software-Carpentry.org/lessons](https://software-carpentry.org/lessons/),  
+[DataCarpentry.org/lessons](https://datacarpentry.org/lessons/) and
+[LibraryCarpentry.org/lessons](https://librarycarpentry.org/lessons/).
 
 If your lesson is in active development, you can expect to see a lot
 of changes to your repo in the near future. Data Carpentry holds an

--- a/_episodes/02-curricular.md
+++ b/_episodes/02-curricular.md
@@ -26,17 +26,9 @@ for development of new lessons. Your involvement with this process
 (and making modifications to this process) will depend on the lesson
 you are a Maintainer for. Some lessons have been around for a while
 and are quite mature and stable, while others are newer and are still in
-active development. As of December 2017, the status of each of the
-Software and Data Carpentry lessons is:
-
-| Lesson  | Status |
-| --------------- | ------ |
-| all SWC lessons | mature |
-| DC Ecology lessons | mature |
-| DC Genomics R | in active development |
-| all other DC Genomics lessons | mature |
-| DC Geospatial lessons | in active development |
-| DC Social Sciences lessons | in active development |
+active development. You can check the status of our lesson rosters on
+[Software-Carpentry.org/lessons](https://software-carpentry.org/lessons/) and 
+[DataCarpentry.org/lessons](https://datacarpentry.org/lessons/).
 
 If your lesson is in active development, you can expect to see a lot
 of changes to your repo in the near future. Data Carpentry holds an


### PR DESCRIPTION
I noticed that `DC Social Sciences lessons | in active development` is no longer 100% the case, as [some of its lesson are no longer tagged with `*alpha*`](https://datacarpentry.org/lessons/#social-science-curriculum).

To avoid such out-dated info in the future, how about declaring the lesson pages as the source of truth and to refer to them only?