### PR TITLE
Updating the links in where to contribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ and to meet some of our community members.
     and can be viewed at <https://carpentries.github.io/lesson-example/>.
 
 3.  If you wish to change the template used for workshop websites,
-    please work in <https://carpentries.github.io/workshop-template/>.
+    please work in <https://github.com/carpentries/workshop-template>.
     The home page of that repository explains how to set up workshop websites,
     while the extra pages in <https://github.com/carpentries/workshop-template>
     provide more background on our design choices.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,19 +50,19 @@ and to meet some of our community members.
     which can be viewed at <https://carpentries.github.io/maintainer-onboarding>.
 
 2.  If you wish to change the example lesson,
-    please work in <https://github.com/swcarpentry/lesson-example>,
+    please work in <https://github.com/carpentries/lesson-example>,
     which documents the format of our lessons
-    and can be viewed at <https://swcarpentry.github.io/lesson-example>.
+    and can be viewed at <https://carpentries.github.io/lesson-example/>.
 
 3.  If you wish to change the template used for workshop websites,
-    please work in <https://github.com/swcarpentry/workshop-template>.
+    please work in <https://carpentries.github.io/workshop-template/>.
     The home page of that repository explains how to set up workshop websites,
-    while the extra pages in <https://swcarpentry.github.io/workshop-template>
+    while the extra pages in <https://github.com/carpentries/workshop-template>
     provide more background on our design choices.
 
 4.  If you wish to change CSS style files, tools,
     or HTML boilerplate for lessons or workshops stored in `_includes` or `_layouts`,
-    please work in <https://github.com/swcarpentry/styles>.
+    please work in <https://github.com/carpentries/styles>.
 
 ## What to Contribute
 


### PR DESCRIPTION
the links were redirecting to carpentries anyway but thought they should be directly reference.
