### PR TITLE
update workflows to fix website builds

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -127,13 +127,14 @@ jobs:
         id: check-rmd
         working-directory: lesson
         run: |
-          echo "::set-output name=count::$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})"
+          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> $GITHUB_OUTPUT
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'release'
+          use-public-rspm: true
+          install-r: false
 
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -44,13 +44,14 @@ jobs:
       - name: Look for R-markdown files
         id: check-rmd
         run: |
-          echo "::set-output name=count::$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})"
+          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> $GITHUB_OUTPUT
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'release'
+          use-public-rspm: true
+          install-r: false
 
       - name: Restore R Cache
         if: steps.check-rmd.outputs.count != 0


### PR DESCRIPTION
I'm basing this off @zkamvar's (many) PRs to fix this issue elsewhere. Quoting him from elsewhere:

> There are two items that are changed:
> 
> 1. r-lib/actions/setup-r now uses `@v2` instead of `@master` as the default tag
> 2. the `set-output` GHA workflow command has been updated as it was deprecated.
> 
> see https://github.com/carpentries/styles/issues/641 for details

