### PR TITLE
Fix URLs in various locations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ In exchange,
 we will address your issues and/or assess your change proposal as promptly as we can,
 and help you become a member of our community.
 Everyone involved in [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-agrees to abide by our [code of conduct](CONDUCT.md).
+agrees to abide by our [code of conduct](CODE_OF_CONDUCT.md).
 
 ## How to Contribute
 
@@ -116,7 +116,7 @@ happens on the [discussion mailing list][discuss-list],
 which everyone is welcome to join.
 You can also [reach us by email][contact].
 
-[contact]: mailto:admin@software-carpentry.org
+[contact]: mailto:team@carpentries.org
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
 [dc-lessons]: http://datacarpentry.org/lessons/
 [dc-site]: http://datacarpentry.org/
@@ -124,9 +124,9 @@ You can also [reach us by email][contact].
 [github]: http://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
-[how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://github.com/swcarpentry/shell-novice/issues/
-[repo]: https://github.com/swcarpentry/shell-novice/
+[how-contribute]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
+[issues]: https://github.com/carpentries/maintainer-onboarding/issues/
+[repo]: https://github.com/carpentries/maintainer-onboarding/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: http://software-carpentry.org/lessons/
 [swc-site]: http://software-carpentry.org/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,16 +118,16 @@ You can also [reach us by email][contact].
 
 [contact]: mailto:team@carpentries.org
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
-[dc-lessons]: http://datacarpentry.org/lessons/
-[dc-site]: http://datacarpentry.org/
+[dc-lessons]: https://datacarpentry.org/lessons/
+[dc-site]: https://datacarpentry.org/
 [discuss-list]: http://lists.software-carpentry.org/listinfo/discuss
-[github]: http://github.com
+[github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://github.com/carpentries/maintainer-onboarding/issues/
 [repo]: https://github.com/carpentries/maintainer-onboarding/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
-[swc-lessons]: http://software-carpentry.org/lessons/
-[swc-site]: http://software-carpentry.org/
+[swc-lessons]: https://software-carpentry.org/lessons/
+[swc-site]: https://software-carpentry.org/
 [template-doc]: https://carpentries.github.io/workbench/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ You can also [reach us by email][contact].
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
 [dc-lessons]: https://datacarpentry.org/lessons/
 [dc-site]: https://datacarpentry.org/
-[discuss-list]: http://lists.software-carpentry.org/listinfo/discuss
+[discuss-list]: https://carpentries.topicbox.com/groups/discuss
 [github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ to updating or filling in the documentation
 and submitting [bug reports][issues]
 about things that don't work, aren't clear, or are missing.
 If you are looking for ideas,
-please see [the list of issues for this repository][issues],
+please see [the list of issues for this repository][repo-issues],
 or the issues for [Data Carpentry][dc-issues]
 and [Software Carpentry][swc-issues] projects.
 
@@ -125,8 +125,9 @@ You can also [reach us by email][contact].
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://github.com/carpentries/maintainer-onboarding/issues/
+[issues]: https://guides.github.com/features/issues/
 [repo]: https://github.com/carpentries/maintainer-onboarding/
+[repo-issues]: https://github.com/carpentries/maintainer-onboarding/issues/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: https://software-carpentry.org/lessons/
 [swc-site]: https://software-carpentry.org/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ In brief, we use [GitHub flow][github-flow] to manage changes:
     1.  Create a new branch in your desktop copy of this repository for each significant change.
     2.  Commit the change in that branch.
     3.  Push that branch to your fork of this repository on GitHub.
-    4.  Submit a pull request from that branch to the [master repository][repo].
+    4.  Submit a pull request from that branch to the [upstream repository][repo].
     5.  If you receive feedback,
         make changes on your desktop and push to your branch on GitHub:
         the pull request will update automatically.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It will familiarize them with our process, the social aspects of dealing with co
 - [Erin Becker](mailto:ebecker@carpentries.org)
 - [Daniel Chen](mailto:chendaniely@gmail.com)
 
-[swc-site]: http://software-carpentry.org
-[dc-site]: http://datacarpentry.org
+[swc-site]: https://software-carpentry.org
+[dc-site]: https://datacarpentry.org
 [lc-site]: https://librarycarpentry.org
 
 

--- a/episodes/03-communicate-maintainers.md
+++ b/episodes/03-communicate-maintainers.md
@@ -41,7 +41,7 @@ Add the monthly Maintainer meetings to your calendar by either
 
 - subscribing to The Carpentries [community calendar](https://carpentries.org/community/#community-events) and
   copying events to your Google Calendar, or
-- clicking the TimeandDate links on the Maintainers [CodiMD pad](https://codimd.carpentries.org/maintainers?both) to convert
+- clicking the TimeandDate links on the [Maintainers CodiMD pad](https://codimd.carpentries.org/maintainers?both) to convert
   the events to your local time, and adding to your calendar manually.
 
 If you are planning to attend the upcoming meeting, add your name to the CodiMD pad to let us know you will be there!

--- a/episodes/03-communicate-maintainers.md
+++ b/episodes/03-communicate-maintainers.md
@@ -67,7 +67,7 @@ place for back-and-forth discussion.
 
 A few lists exist around specific curricula (search for lists starting with `curriculum`, but most have not been very active.
 If you would like to have a public TopicBox list created for discussions of your lesson, or a private list for your Maintainer
-team, please [let us know](mailto: [team@carpentries.org](mailto:team@carpentries.org)).
+team, please [let us know](mailto:team@carpentries.org).
 
 ### Slack
 
@@ -78,7 +78,7 @@ on specific issues and PRs. Most curricula also have a public Slack channel for 
 for channels starting with `dc`, `lc`, or `swc`). Specific curriculum channels have not historically been very active,
 but we encourage any efforts to increase interaction with the community on these channels. You can also use curriculum-specific
 channels for communicating with your co-Maintainers, or you can create a private channel for yourself and your co-Maintainers.
-If you would like a private channel to be created for you, please [let us know](mailto: [team@carpentries.org](mailto:team@carpentries.org)).
+If you would like a private channel to be created for you, please [let us know](mailto:team@carpentries.org).
 
 ### GitHub
 


### PR DESCRIPTION
I spotted various broken URLs:

- Markdown links as target for email addresses
- outdated, conflated and incorrectly copied links in CONTRIBUTING
- HTTP instead of HTTPS URLs in the README and CONTRIBUTING

In one of the episodes, I included "Maintainers" in the link text, so that it reads "Maintainers CodiMD pad" instead of just "CodiMD pad". In the contributing guide, I replaced "master repository" with "upstream repository" to distinguish repositories by their role.