### PR TITLE
Use different header level and include periods in abbreviation

### DIFF
--- a/episodes/02-communicate-contributors.md
+++ b/episodes/02-communicate-contributors.md
@@ -55,7 +55,7 @@ making it more likely that their contribution will be useful and accepted.
 Locate your lesson's help wanted list.
 
 - How many issues are currently open with that tag? How many have been closed?
-- Is it clear what action is desired (ie what help is wanted?) for each issue marked help wanted?
+- Is it clear what action is desired (i.e. what help is wanted?) for each issue marked help wanted?
 - Are there any old issues that are out of date and are still marked help wanted?
 - Are there any new issues that should have the help wanted tag and don't?
 

--- a/episodes/05-infrastructure.md
+++ b/episodes/05-infrastructure.md
@@ -280,7 +280,7 @@ Although these repository files may be occasionally updated, Maintainers can mos
 
 ![The organisation of a typical lesson repository. Note that this figure contains some files and folders that may not be found in every lesson repository. Refer to the rest of this episode, and the full Workbench documentation, for a list of the minimum set of files and folders that are required for a lesson repository to build successfully.](fig/repo-organisation.png){alt="The contents of a typical lesson repository, with files and folders labeled according to whether they are relevant to the lesson content, the lesson repository, or the lesson infrastructure, and whether they are specific to R Markdown-based lessons or not."}
 
-### Full Infrastructure Documentation
+## Full Infrastructure Documentation
 
 For a step-by-step guide to how the lessons are structured, and what syntax to use to add code
 chunks, exercises, and other elements, please read the


### PR DESCRIPTION
Another two small fixes:

- "ie" -> "i.e.", following the style guide
- the last section in episode 5 was not clearly a subsection to the previous header, so I updated its header level from 3 to 2