### PR TITLE
Change caution to spoiler

### DIFF
--- a/episodes/02-communicate-contributors.md
+++ b/episodes/02-communicate-contributors.md
@@ -169,7 +169,7 @@ take a look at this guide on [How to label issues](https://docs.carpentries.org/
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-:::::::::::::::::::::::::::::::::::::::::  caution
+:::::::::::::::::::::::::::::::::::::::::  spoiler
 
 ### Bots and Spam
 


### PR DESCRIPTION
Replace bots and spam caution callout with spoiler type so it isn't expanded by default

Please delete this line and the text below before submitting your contribution.
